### PR TITLE
Changed gcd import

### DIFF
--- a/braidtest.py
+++ b/braidtest.py
@@ -1,6 +1,6 @@
 """Unit test for braid.py"""
 
-from fractions import gcd
+from math import gcd
 from braid import *
 import unittest
 import time  # benchmarking

--- a/grading.py
+++ b/grading.py
@@ -1,6 +1,7 @@
 """Handles grading groups and grading sets."""
 
-from fractions import Fraction, gcd
+from fractions import Fraction
+from math import gcd
 from numbers import Number
 from linalg import RowSystem
 from utility import flatten, grTypeStr, memorize, oppSide, sideStr, tolist

--- a/utility.py
+++ b/utility.py
@@ -1,6 +1,6 @@
 """Various utilities useful for the project."""
 
-from fractions import gcd
+from math import gcd
 from numbers import Number
 
 def memorize(function):


### PR DESCRIPTION
Starting in Python 3.9, there is no `fractions.gcd`, just `math.gcd`.  Since `math.gcd` existed even earlier than Python 3.6 (which list `fractions.gcd` as deprecated), I simply switched the three occurances over to `math.gcd`.